### PR TITLE
Use custom lager sink

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 
-{erl_opts, [{parse_transform, lager_transform}]}.
+{erl_opts, [{parse_transform, lager_transform}, {lager_extra_sinks, [aeminer]}]}.
 
 {deps, [
         {lager, {git, "https://github.com/erlang-lager/lager.git",

--- a/src/aeminer_pow_cuckoo.erl
+++ b/src/aeminer_pow_cuckoo.erl
@@ -106,12 +106,12 @@
        (is_integer(EdgeBits) and (EdgeBits > 0)) and
        (is_list(Instances) or (Instances =:= undefined))).
 
--define(LOG_MODULE, application:get_env(aeminer, log_module)).
+-define(LOG_SINK, (application:get_env(aeminer, lager_log_sink, lager))).
 
--define(debug(F, A), lager:debug(F, A)).
--define(info(F, A),  lager:info(F, A)).
--define(warning(F, A), lager:warning(F, A)).
--define(error(F, A), lager:error(F, A)).
+-define(debug(F, A), ?LOG_SINK:debug(F, A)).
+-define(info(F, A),  ?LOG_SINK:info(F, A)).
+-define(warning(F, A), ?LOG_SINK:warning(F, A)).
+-define(error(F, A), ?LOG_SINK:error(F, A)).
 
 %%%=============================================================================
 %%% API

--- a/src/aeminer_pow_cuckoo.erl
+++ b/src/aeminer_pow_cuckoo.erl
@@ -106,12 +106,10 @@
        (is_integer(EdgeBits) and (EdgeBits > 0)) and
        (is_list(Instances) or (Instances =:= undefined))).
 
--define(LOG_SINK, (application:get_env(aeminer, lager_log_sink, lager))).
-
--define(debug(F, A), ?LOG_SINK:debug(F, A)).
--define(info(F, A),  ?LOG_SINK:info(F, A)).
--define(warning(F, A), ?LOG_SINK:warning(F, A)).
--define(error(F, A), ?LOG_SINK:error(F, A)).
+-define(debug(F, A), aeminer:debug(F, A)).
+-define(info(F, A),  aeminer:info(F, A)).
+-define(warning(F, A), aeminer:warning(F, A)).
+-define(error(F, A), aeminer:error(F, A)).
 
 %%%=============================================================================
 %%% API


### PR DESCRIPTION
Because aeminer is used as a dependency in a larger node, it needs to use its own lager sink so it doesn't log into the default lager sink of the top level application.