### PR TITLE
Export instance/0 and instances/0 types

### DIFF
--- a/src/aeminer_pow_cuckoo.erl
+++ b/src/aeminer_pow_cuckoo.erl
@@ -34,6 +34,8 @@
               extra_args/0,
               hex_enc_header/0,
               repeats/0,
+              instance/0,
+              instances/0,
               edge_bits/0,
               solution/0,
               config/0


### PR DESCRIPTION
This is required for `aestratum_lib`.