### PR TITLE
Dialyzer fixes

### DIFF
--- a/src/aeminer_pow.erl
+++ b/src/aeminer_pow.erl
@@ -24,7 +24,7 @@
 
 -include("aeminer.hrl").
 
--type nonce()      :: 0..?MAX_NONCE.
+-type nonce()      :: ?MIN_NONCE..?MAX_NONCE.
 
 -type int_target() :: integer().
 

--- a/src/aeminer_pow_cuckoo.erl
+++ b/src/aeminer_pow_cuckoo.erl
@@ -58,11 +58,11 @@
 -type instance()          :: aeminer_pow:instance()
                            | undefined.
 
--type exec()              :: string().
+-type exec()              :: binary().
 
 -type exec_group()        :: binary().
 
--type extra_args()        :: string().
+-type extra_args()        :: binary().
 
 -type hex_enc_header()    :: boolean().
 
@@ -120,9 +120,9 @@
 config(Exec, ExecGroup, ExtraArgs, HexEncHdr, Repeats, EdgeBits, Instances) when
       ?IS_CONFIG(Exec, ExecGroup, ExtraArgs, HexEncHdr, Repeats, EdgeBits, Instances) ->
     #config{
-       exec           = binary_to_list(Exec),
+       exec           = Exec,
        exec_group     = ExecGroup,
-       extra_args     = binary_to_list(ExtraArgs),
+       extra_args     = ExtraArgs,
        hex_enc_header = HexEncHdr,
        repeats        = Repeats,
        edge_bits      = EdgeBits,
@@ -204,17 +204,20 @@ verify(Data, Nonce, Soln, Target, EdgeBits) when
 %% Internal functions.
 
 generate_int(Hash, Nonce, Target,
-             #config{exec = Exec, extra_args = ExtraArgs0,
+             #config{exec = Exec0, extra_args = ExtraArgs0,
                      hex_enc_header = HexEncHdr} = Config, Instance) ->
-    ExtraArgs   = case is_miner_instance_addressation_enabled(Config) of
-                      true  -> ExtraArgs0 ++ " -d " ++ integer_to_list(Instance);
-                      false -> ExtraArgs0
-                  end,
-    EncodedHash = case HexEncHdr of
-                      true  -> hex_string(Hash);
-                      false -> Hash
-                  end,
+    ExtraArgs =
+        case is_miner_instance_addressation_enabled(Config) of
+            true  -> binary_to_list(ExtraArgs0) ++ " -d " ++ integer_to_list(Instance);
+            false -> binary_to_list(ExtraArgs0)
+        end,
+    EncodedHash =
+        case HexEncHdr of
+            true  -> hex_string(Hash);
+            false -> Hash
+        end,
     ExecBinDir  = exec_bin_dir(Config),
+    Exec = binary_to_list(Exec0),
     generate_int(EncodedHash, Nonce, Target, ExecBinDir, Exec, ExtraArgs, Config).
 
 generate_int(Hash, Nonce, Target, MinerBinDir, MinerBin, MinerExtraArgs,

--- a/src/aeminer_pow_cuckoo.erl
+++ b/src/aeminer_pow_cuckoo.erl
@@ -464,7 +464,7 @@ parse_generation_result(["Solution" ++ NonceValuesStr | Rest],
     [NonceStr | SolStrs] =  string:tokens(NonceValuesStr, " "),
     Soln = [list_to_integer(string:trim(V, both, [$\r]), 16) || V <- SolStrs],
     case {length(Soln), test_target(Soln, Target, EdgeBits)} of
-        {42, true} ->
+        {?SOLUTION_SIZE, true} ->
             stop_execution(OsPid),
             case parse_nonce_str(NonceStr) of
                 {ok, Nonce} ->
@@ -474,8 +474,8 @@ parse_generation_result(["Solution" ++ NonceValuesStr | Rest],
                     ?debug("Bad nonce: ~p", [Err]),
                     Err
             end;
-        {N, _} when N /= 42 ->
-            ?debug("Solution has wrong length (~p) should be 42", [N]),
+        {N, _} when N /= ?SOLUTION_SIZE ->
+            ?debug("Solution has wrong length (~p) should be ~p", [N, ?SOLUTION_SIZE]),
             %% No nonce in solution, old miner exec?
             stop_execution(OsPid),
             {error, bad_miner};

--- a/test/aeminer_pow_cuckoo_tests.erl
+++ b/test/aeminer_pow_cuckoo_tests.erl
@@ -26,7 +26,7 @@ pow_test_() ->
                 Config = fast_and_deterministic_cuckoo_pow(),
                 Res = spawn_worker(fun() -> ?TEST_MODULE:generate(?TEST_BIN, Target, Nonce, Config, undefined) end),
                 {ok, {Nonce, Soln}} = Res,
-                ?assertMatch(L when length(L) == 42, Soln),
+                ?assertMatch(L when length(L) == ?SOLUTION_SIZE, Soln),
 
                 %% verify the nonce and the solution
                 Res2 = ?TEST_MODULE:verify(?TEST_BIN, Nonce, Soln, Target, ?EDGE_BITS_15),
@@ -53,7 +53,7 @@ pow_test_() ->
                                             ?TEST_MODULE:generate(?TEST_BIN, HighTarget, Nonce, Config, undefined)
                                     end),
                 {ok, {Nonce, Soln2}} = Res2,
-                ?assertMatch(L when length(L) == 42, Soln2),
+                ?assertMatch(L when length(L) == ?SOLUTION_SIZE, Soln2),
                 %% ... then attempt to verify such solution (and
                 %% nonce) with the low target threshold (shall fail).
                 ?assertNot(?TEST_MODULE:verify(?TEST_BIN, Nonce, Soln2, Target, ?EDGE_BITS_15))
@@ -66,10 +66,10 @@ pow_test_() ->
                Config = fast_and_deterministic_cuckoo_pow(),
                Res = spawn_worker(fun() -> ?TEST_MODULE:generate(?TEST_BIN, Target, Nonce, Config, undefined) end),
                {ok, {Nonce, Soln}} = Res,
-               ?assertMatch(L when length(L) == 42, Soln),
+               ?assertMatch(L when length(L) == ?SOLUTION_SIZE, Soln),
 
                WrongSoln = lists:seq(0, 41),
-               ?assertMatch(L when length(L) == 42, WrongSoln),
+               ?assertMatch(L when length(L) == ?SOLUTION_SIZE, WrongSoln),
                ?assertNotEqual(Soln, WrongSoln),
                ?assertNot(?TEST_MODULE:verify(?TEST_BIN, Nonce, WrongSoln, Target, ?EDGE_BITS_15))
        end},
@@ -82,7 +82,7 @@ pow_test_() ->
                spawn_worker(fun() -> ?TEST_MODULE:generate(?TEST_BIN, Target, Nonce, Config, undefined) end)),
 
                DummySoln = lists:seq(0, 41),
-               ?assertMatch(L when length(L) == 42, DummySoln),
+               ?assertMatch(L when length(L) == ?SOLUTION_SIZE, DummySoln),
                ?assertNot(?TEST_MODULE:verify(?TEST_BIN, Nonce, DummySoln, Target, ?EDGE_BITS_15))
        end},
       {"Attempt to verify nonce that is too big shall fail gracefully",


### PR DESCRIPTION
Defines from .hrl file are used in the code.

`exec()` and `extra_args()` have `binary()` type to avoid issues with dialyzer.