### PR TITLE
Export verify_proof/4 and add get_target/2

### DIFF
--- a/src/aeminer_pow.erl
+++ b/src/aeminer_pow.erl
@@ -136,12 +136,6 @@ test_target(Bin, Target) ->
     <<Val:32/big-unsigned-integer-unit:8>> = Bin,
     Val < Threshold.
 
-%% TODO: get target
-%Bin = solution_to_binary(lists:sort(Soln), NodeSize * 8, <<>>),
-%%Hash = aec_hash:hash(pow, Bin),
-%%<<Val:32/big-unsigned-integer-unit:8>> = Hash,
-%%Val
-
 %%%=============================================================================
 %%% Internal functions
 %%%=============================================================================


### PR DESCRIPTION
Must be merged after #7 

`verify_proof/4` checks that a solution is a valid solution it doesn't check it against any target.

`get_target/2` returns the target of a solution in integer form (not scientific).

Both functions are needed in Stratum.