### PR TITLE
Extend API with functions required in Stratum

### DIFF
--- a/src/aeminer_blake2b_256.erl
+++ b/src/aeminer_blake2b_256.erl
@@ -6,12 +6,14 @@
               hash/0
              ]).
 
+-define(HASH_BYTES_SIZE, 32).
+
 -type hashable() :: binary().
 
--type hash()     :: binary().
+-type hash()     :: <<_:(?HASH_BYTES_SIZE * 8)>>.
 
 -spec hash(hashable()) -> hash().
 hash(Bin) ->
-    {ok, Hash} = enacl:generichash(32, Bin),
+    {ok, Hash} = enacl:generichash(?HASH_BYTES_SIZE, Bin),
     Hash.
 


### PR DESCRIPTION
The `aeminer_pow_cuckoo:generate/5` has the `Data` parameter, which is a serialized header binary of size 364 bytes, which is hashed to 64 bytes and then used as the input of the miner itself. This is ok if the miner and the ae node are on the same machine.

However, when Stratum notifies workers about a new job, it needs to send the `Data` part and its size should be limited. It's preferable to send 64 bytes, so there are 2 new functions in the API:
* `hash_data/1` - converts 364 bytes of data to 64 bytes
* `generate_from_hash/5` - just like `generate/5`, but doesn't convert its input `Data` to 64 bytes, it expects the 64 bytes input