### PR TITLE
Replace direct lager logging with hut

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
        ]}.
 
 {plugins, [{rebar_aecuckooprebuilt_dep, {git, "https://github.com/aeternity/rebar3-cuckoo-prebuilt-plugin.git",
-                                         {ref, "4f0a0c64132f837ee47cfaf99cddafabfe4fd7f1"}}}
+                                         {ref, "3981d79"}}}
           ]}.
 
 {profiles, [{test, [{deps, [{meck, "0.8.13"}]}]}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,9 +1,5 @@
-
-{erl_opts, [{parse_transform, lager_transform}, {lager_extra_sinks, [aeminer]}]}.
-
 {deps, [
-        {lager, {git, "https://github.com/erlang-lager/lager.git",
-                 {ref, "69b4ada"}}}, % tag: 3.6.7
+        {hut, "1.3.0"},
 
         %% Cuckoo prebuilt CUDA binaries.
         {aecuckooprebuilt,
@@ -23,7 +19,7 @@
                                          {ref, "4f0a0c64132f837ee47cfaf99cddafabfe4fd7f1"}}}
           ]}.
 
-{profiles, [{test, [{deps, [{meck, "0.8.12"}]}]}]}.
+{profiles, [{test, [{deps, [{meck, "0.8.13"}]}]}]}.
 
 {dialyzer, [{warnings, [unknown]},
             {plt_apps, all_deps},

--- a/rebar.lock
+++ b/rebar.lock
@@ -12,12 +12,8 @@
   {git,"https://github.com/aeternity/enacl.git",
       {ref,"26180f42c0b3a450905d2efd8bc7fd5fd9cece75"}},
   0},
- {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
- {<<"lager">>,
-  {git,"https://github.com/erlang-lager/lager.git",
-      {ref,"69b4ada2341b8ab2cf5c8e464ac936e5e4a9f62b"}},
-  0}]}.
+ {<<"hut">>,{pkg,<<"hut">>,<<"1.3.0">>},0}]}.
 [
 {pkg_hash,[
- {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>}]}
+ {<<"hut">>, <<"71F2F054E657C03F959CF1ACC43F436EA87580696528CA2A55C8AFB1B06C85E7">>}]}
 ].

--- a/src/aeminer.app.src
+++ b/src/aeminer.app.src
@@ -5,8 +5,8 @@
   {applications,
    [kernel,
     stdlib,
-    lager,
     enacl,
+    hut,
     aecuckoo,
     aecuckooprebuilt
    ]},


### PR DESCRIPTION
This ensures we can configure the logging backend in the umbrella project
where aeminer is used.

See https://github.com/aeternity/aeternity/issues/2923