### PR TITLE
WIP: AE_DISABLE_CUCKOO env var support

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,5 +1,4 @@
 %% -*- mode:erlang; erlang-indent-level:4; indent-tabs-mode:nil -*-
-io:fwrite("Running ~p~n", [SCRIPT]).
 case os:getenv("AE_DISABLE_CUCKOO") =/= false of
     true ->
         RemoveApps = [aecuckoo, aecuckooprebuilt],
@@ -11,10 +10,7 @@ case os:getenv("AE_DISABLE_CUCKOO") =/= false of
         CONFIG1 = lists:keyreplace(deps, 1, CONFIG, {deps, NewDeps}),
         Plugins1 = [P || P <- Plugins,
                          not lists:member(element(1,P), RemovePlugins)],
-        CONFIG2 = lists:keystore(plugins, 1, CONFIG1, {plugins, Plugins1}),
-        io:fwrite("CONFIG2 = ~p~n", [CONFIG2]),
-        CONFIG2;
+        lists:keystore(plugins, 1, CONFIG1, {plugins, Plugins1});
     false ->
-        io:fwrite("Using cuckoo~n", []),
         CONFIG
 end.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,20 @@
+%% -*- mode:erlang; erlang-indent-level:4; indent-tabs-mode:nil -*-
+io:fwrite("Running ~p~n", [SCRIPT]).
+case os:getenv("AE_DISABLE_CUCKOO") =/= false of
+    true ->
+        RemoveApps = [aecuckoo, aecuckooprebuilt],
+        RemovePlugins = [rebar_aecuckooprebuilt_dep],
+        {_, Deps} = lists:keyfind(deps, 1, CONFIG),
+        NewDeps = [D || D <- Deps,
+                        not lists:member(element(1,D), RemoveApps)],
+        Plugins = proplists:get_value(plugins, CONFIG, []),
+        CONFIG1 = lists:keyreplace(deps, 1, CONFIG, {deps, NewDeps}),
+        Plugins1 = [P || P <- Plugins,
+                         not lists:member(element(1,P), RemovePlugins)],
+        CONFIG2 = lists:keystore(plugins, 1, CONFIG1, {plugins, Plugins1}),
+        io:fwrite("CONFIG2 = ~p~n", [CONFIG2]),
+        CONFIG2;
+    false ->
+        io:fwrite("Using cuckoo~n", []),
+        CONFIG
+end.

--- a/rebar.lock.script
+++ b/rebar.lock.script
@@ -1,0 +1,29 @@
+%% -*- erlang -*-
+
+FilterCheck = (os:getenv("AE_DISABLE_CUCKOO") =/= false),
+RemoveApps = [<<"aecuckoo">>, <<"aecuckooprebuilt">>],
+
+Filter = fun(Apps) ->
+                 case FilterCheck of
+                     false ->
+                         Apps;
+                     true ->
+                         lists:foldl(
+                           fun(App, Acc) ->
+                                   lists:keydelete(App, 1, Acc)
+                           end,
+                           Apps,
+                           RemoveApps
+                          )
+                 end
+         end,
+
+case CONFIG of
+    [] ->
+        %% no lock file present, usually during unlock/upgrade
+        CONFIG;
+    [{Version, Deps}, [{pkg_hash, Pkgs}]] ->
+        Deps1 = Filter(Deps),
+        Pkgs1 = Filter(Pkgs),
+        [{Version, Deps1}, [{pkg_hash, Pkgs1}]]
+end.

--- a/src/aeminer.app.src.script
+++ b/src/aeminer.app.src.script
@@ -1,0 +1,18 @@
+%% -*- mode:erlang; erlang-indent-level:4; indent-tabs-mode:nil -*-
+
+RemoveApps = [aecuckoo, aecuckooprebuilt].
+Base = filename:basename(SCRIPT, ".script").
+Dir = filename:dirname(SCRIPT).
+{ok, [{application,_,Opts} = App]} = file:consult(filename:join(Dir, Base)).
+case os:getenv("AE_DISABLE_CUCKOO") =/= false of
+    true ->
+        {_, Apps} = lists:keyfind(applications, 1, Opts),
+        Env = proplists:get_value(env, Opts, []),
+        Env1 = lists:keystore(use_cuckoo, 1, Env, {use_cuckoo, false}),
+        Apps1 = Apps -- RemoveApps,
+        Opts1 = lists:keyreplace(applications, 1, Opts, {applications, Apps1}),
+        Opts2 = lists:keystore(env, 1, Opts1, {env, Env1}),
+        setelement(3, App, Opts2);
+    false ->
+        App
+end.


### PR DESCRIPTION
This is work in progress, experimenting with getting an `ae` node to build and run on `termux` (Android).

The idea is to introduce an os env variable, `AE_DISABLE_CUCKOO=true` (since `cuckoo` is hard to compile on `termux`). This would remove `cuckoo`-related deps, also remove the corresponding app deps from the `aeminer.app` file, and set an OTP environment variable, `{use_cuckoo, false}`.

Similar things need to be done in the `aeternity` repos regarding `aestratum`, which also depends on `cuckoo`